### PR TITLE
Remove calls to std::move on returns

### DIFF
--- a/nifpp.h
+++ b/nifpp.h
@@ -703,7 +703,7 @@ resource_ptr<T> construct_resource(Args&&... args)
 
         // ctor succeeded, enable dtor
         reinterpret_cast<detail::dtor_wrapper<T>*>(mem)->constructed = true;
-        return std::move(rptr);
+        return rptr;
     }
     else
     {
@@ -1094,7 +1094,7 @@ T get(ErlNifEnv *env, ERL_NIF_TERM term)
     T temp;
     if(get(env, term, temp))
     {
-        return std::move(temp);
+        return temp;
     }
     throw badarg();
 }


### PR DESCRIPTION
Fixes GCC warnings:

```
In file included from c_libs/common.h:4,
                 from c_libs/table.h:3,
                 from c_libs/table.cpp:1:
3rdparty/nifpp/nifpp.h: In instantiation of ‘nifpp::resource_ptr<T> nifpp::construct_resource(Args&& ...) [with T = std::shared_ptr<arrow::Table>; Args = {std::shared_ptr<arrow::Table>&}]’:
c_libs/table.cpp:51:78:   required from here
3rdparty/nifpp/nifpp.h:706:30: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  706 |         return std::move(rptr);
      |                              ^
3rdparty/nifpp/nifpp.h:706:30: note: remove ‘std::move’ call
3rdparty/nifpp/nifpp.h: In instantiation of ‘T nifpp::get(ErlNifEnv*, ERL_NIF_TERM) [with T = std::__cxx11::basic_string<char>; ErlNifEnv = enif_environment_t; ERL_NIF_TERM = long unsigned int]’:
c_libs/table.cpp:189:61:   required from here
3rdparty/nifpp/nifpp.h:1097:30: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
 1097 |         return std::move(temp);
      |                              ^
3rdparty/nifpp/nifpp.h:1097:30: note: remove ‘std::move’ call
```