### PR TITLE
Support generating map of maps

### DIFF
--- a/examples/nifpptest.cpp
+++ b/examples/nifpptest.cpp
@@ -64,6 +64,27 @@ nifpp::TERM mapflip_test(ErlNifEnv* env, ERL_NIF_TERM term)
     return make(env, outmap);
 }
 
+// Build a nested map
+nifpp::TERM nestedmap_test(ErlNifEnv* env, ERL_NIF_TERM )
+{
+	std::map<nifpp::str_atom, int> int_map = {
+        {"a", 1}
+	};
+    nifpp::TERM outmap = make(env, int_map);
+
+    // Add another entry to map
+    add_to_map(env, std::make_pair(str_atom("b"), "b"), outmap);
+
+    // Add a nested map
+    std::map<nifpp::str_atom, int> nested_map = {
+        {"a1" , 1},
+        {"b1" , 2}
+    };
+    add_to_map(env, std::make_pair(str_atom("c"), make(env, nested_map)), outmap);
+
+    return outmap;
+}
+
 // swap keys and values (unordered_map version.  I would templatize the abstract map type if I knew how)
 template<typename TK, typename TV>
 nifpp::TERM umapflip_test(ErlNifEnv* env, ERL_NIF_TERM term)
@@ -311,6 +332,8 @@ ERL_NIF_TERM nif_main(ErlNifEnv* env, nifpp::TERM term)
 
     else if(cmd=="mapflipba") { return  mapflip_test<nifpp::str_atom, int>(env, cmddata); }
     else if(cmd=="mapflipbb") { return umapflip_test<nifpp::str_atom, int>(env, cmddata); }
+
+    else if(cmd=="nestedmap") { return nestedmap_test(env, cmddata); }
 
     // basic resource testing
     else if(cmd=="makeresint")

--- a/examples/nifpptest.erl
+++ b/examples/nifpptest.erl
@@ -174,7 +174,8 @@ map_test_() ->
         ?_assertEqual(#{123 => abc,456 => def,789 => pqr}, invoke_nif({mapflipaa, #{abc=>123, def=>456, pqr=>789}})),
         ?_assertEqual(#{123 => abc,456 => def,789 => pqr}, invoke_nif({mapflipab, #{abc=>123, def=>456, pqr=>789}})),
         ?_assertEqual(#{123 => abc,456 => def,789 => pqr}, invoke_nif({mapflipba, #{abc=>123, def=>456, pqr=>789}})),
-        ?_assertEqual(#{123 => abc,456 => def,789 => pqr}, invoke_nif({mapflipbb, #{abc=>123, def=>456, pqr=>789}}))
+        ?_assertEqual(#{123 => abc,456 => def,789 => pqr}, invoke_nif({mapflipbb, #{abc=>123, def=>456, pqr=>789}})),
+        ?_assertEqual( #{a => 1,b => "b",c => #{a1 => 1,b1 => 2}}, invoke_nif({nestedmap, #{}}))
 
 %% these are no good, they depend on iteration order which is undefined.
 %%         ?_assertEqual(#{123 => abc,456 => def}, invoke_nif({mapflipaa, #{abc=>123, def=>456, def=>123}})),
@@ -237,4 +238,4 @@ bin_test_() ->
     end
     ].
             
-            
+


### PR DESCRIPTION
Add API to be able to add entries to map. And modify existing map's make() API to be able to accept an existing map to add to.

Added a new testcase nestedmap_test to demonstrate this.

Signed-off-by: Vasu Dasari <vdasari@gmail.com>